### PR TITLE
fixed shebang, missing sys path for b-series

### DIFF
--- a/tinyfpga-programmer-gui.py
+++ b/tinyfpga-programmer-gui.py
@@ -1,4 +1,4 @@
-#!python2.7
+#!/usr/bin/env python2.7
 import sys
 import os
 
@@ -6,6 +6,7 @@ import os
 script_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(script_path, 'pkgs'))
 sys.path.insert(0, os.path.join(script_path, 'a-series-programmer', 'python'))
+sys.path.insert(0, os.path.join(script_path, 'b-series', 'programmer'))
 
 import serial
 import array


### PR DESCRIPTION
Hi, I had to make these changes to get the gui to work correctly on my system.
It was missing a path for the b-series module.
The #!python2.7 didn't work on my linux Mint distro.  I changed to the recommended standard shebang.